### PR TITLE
save checkpoint after improvement on validation

### DIFF
--- a/models/model.py
+++ b/models/model.py
@@ -1,6 +1,6 @@
 import keras
 from keras import backend as K
-from keras.callbacks import CSVLogger, ModelCheckpoint, TensorBoard
+from keras.callbacks import CSVLogger, TensorBoard
 import numpy as np
 
 from .parallel_model import to_multi_gpu, get_gpu_max_number
@@ -67,9 +67,8 @@ class Model(object):
 		print("Fitting on data of size", self.input_shape)
 
 		csv_logger = CSVLogger('train/training.log')
-		checkpoint = ModelCheckpoint(filepath='train/checkpoint.hdf5', monitor='binary_crossentropy', verbose=1, save_best_only=True)
 		tensorboard = TensorBoard(log_dir='train/tensorboard', histogram_freq=1, write_graph=True, write_images=True, embeddings_freq=1)
-		callbacks = [csv_logger, checkpoint, tensorboard]
+		callbacks = [csv_logger, tensorboard]
 
 		if validating:
 			(x_validate, y_validate) = self.data.validationSet(self.image_data_fmt, self.input_shape)
@@ -83,7 +82,13 @@ class Model(object):
 					[LABELS[i] for i, x in enumerate(expectation) if x == 1]
 				) for prediction, expectation in zip(predictions, expectations)])
 
-			validationCheckpoint = ValidationCheckpoint(scoring=score, validation_input=x_validate, validation_output=y_validate, patience=5)
+			validationCheckpoint = ValidationCheckpoint(
+				scoring=score,
+				validation_input=x_validate,
+				validation_output=y_validate,
+				checkpoint_path="train/checkpoint.hdf5",
+				patience=5
+			)
 			callbacks.append(validationCheckpoint)
 
 		if generating:

--- a/validation_checkpoint.py
+++ b/validation_checkpoint.py
@@ -5,9 +5,10 @@ class ValidationCheckpoint(Callback):
 	Callback tomeasure performance on validation set
 	- Parameter scoring: a function that takes (model, input, output) and returns a score
 	- Parameter patience: the number of epoch without improvement that can be tolerated
+	- Parameter checkpoint_path: path to where the checkpoint of the best model should be saved
 	"""
 
-	def __init__(self, scoring, validation_input, validation_output, patience=1):
+	def __init__(self, scoring, validation_input, validation_output, checkpoint_path, patience=1):
 		super(ValidationCheckpoint, self).__init__()
 		self.scoring = scoring
 		self.validation_input = validation_input
@@ -16,6 +17,7 @@ class ValidationCheckpoint(Callback):
 		self.best_epoch = -1
 		self.patience = patience
 		self.remaining_patience = patience
+		self.checkpoint_path = checkpoint_path
 
 	def on_epoch_end(self, epoch, logs=None):
 		print("Scoring validation_inputdation set...".format(epoch=epoch))
@@ -31,3 +33,4 @@ class ValidationCheckpoint(Callback):
 			self.best_score = score
 			self.remaining_patience = self.patience
 			self.best_epoch = epoch
+			self.model.save(self.checkpoint_path, overwrite=True)


### PR DESCRIPTION
Since the checkpoint is not working very well, and not in all cases, I'm using the validation we're doing to save the best checkpoint. For instance on the VGG16 we recently got:
```
/usr/local/lib/python3.4/dist-packages/keras/callbacks.py:389: RuntimeWarning: Can save best model only with binary_crossentropy available, skipping.
```